### PR TITLE
Mirror test-templates rel/* branches

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -576,7 +576,7 @@
         "https://github.com/dotnet/templating/blob/main/**/*",
         "https://github.com/dotnet/templating/blob/release/**/*",
         "https://github.com/dotnet/test-templates/blob/main/**/*",
-        "https://github.com/dotnet/test-templates/blob/release/**/*",
+        "https://github.com/dotnet/test-templates/blob/rel/**/*",
         "https://github.com/dotnet/toolset/blob/release/**/*",
         "https://github.com/dotnet/try-convert/blob/main/**/*",
         "https://github.com/dotnet/try-convert/blob/release/**/*",


### PR DESCRIPTION
We do not use the release/* pattern so replace it with rel/* that is actually used